### PR TITLE
chore(backend): harden local config and secret handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ frontend/.vercel
 frontend/*.tsbuildinfo
 frontend/next-env.d.ts
 
-# Variáveis de ambiente
+# Vari?veis de ambiente
 frontend/.env
 frontend/.env.*
 frontend/.env*.local
@@ -41,15 +41,16 @@ frontend/.env*.local
 # =========================
 # .NET / C# (Backend)
 # =========================
-# Pastas de compilação (Arquivos binários pesados)
+# Pastas de compila??o (Arquivos bin?rios pesados)
 backend/bin/
 backend/obj/
 
-# Arquivo de configuração sensível local
+# Arquivo de configura??o sens?vel local
 backend/appsettings.Development.json
 backend/appsettings.*.json
+!backend/appsettings.Example.json
 
-# Arquivos de cache e usuário do Visual Studio / VS Code
+# Arquivos de cache e usu?rio do Visual Studio / VS Code
 *.user
 *.suo
 .vscode/

--- a/README.md
+++ b/README.md
@@ -2,48 +2,69 @@
 
 ![Banner Agentic Prompt Builder](https://raw.githubusercontent.com/OpenRouter/OpenRouter/main/assets/readme-banner.png)
 
-Este projeto implementa uma arquitetura **Sênior** de "Agentic Prompting", utilizando uma pipeline de Múltiplos Agentes LLM (Large Language Models) gratuitos através do [OpenRouter](https://openrouter.ai).
+Este projeto implementa uma arquitetura senior de "Agentic Prompting", utilizando uma pipeline de multiplos agentes LLM atraves do [OpenRouter](https://openrouter.ai).
 
-O objetivo é pegar uma _ideia bruta e caótica_ do usuário e passar por 4 etapas neurais até transformá-la no _Prompt Otimizado Perfeito_ que instruirá uma IA de forma profissional e inequívoca, mitigando as limitações do conhecimento e do foco comum entre as abordagens de prompts zero-shot.
-
----
-
-## 🏗️ Arquitetura (Múltiplos Agentes)
-
-O motor C# (Backend) orquestra a chamada de distintos LLMs para funções altamente específicas. O Frontend atua como a área de visualização reativa (UI) destas etapas:
-
-1. **Agente de Triagem de Complexidade (Etapa -1)**: Detecta se o que você pediu contém _múltiplas funcionalidades disfarçadas de uma só_. Se sim, ele fragmenta e recomenda módulos menores.
-2. **Agente de Identificação de Papel e Formato (Etapa 0)**: Entende _quem_ o LLM final precisa ser (ex: "Engenheiro Frontend Sênior especializado em React") e como o payload deve ser formatado.
-3. **Agente Analítico (Etapa 1)**: Não visa gerar a resposta, mas atuar como o advogado do diabo, analisando deficiências e encontrando os 3 maiores "gotchas" técnicos ou de contexto da sua ideia.
-4. **Agente Gerador de Super Prompt (Etapa 2)**: Responsável exclusivamente por montar e modular o template final unindo TUDO o que foi analisado antes.
-5. **Agente Avaliador Sênior (Etapa 3)**: Valida os prompts gerados em Etapa 2. Fazendo loop reflexivo (se baseando em regras sintáticas estritas), ele refatora pontos fracos e entrega um "Quality Score Final" de aprovação.
+O objetivo e pegar uma ideia bruta do usuario e passar por etapas de classificacao, clarificacao, triagem, analise, geracao e validacao ate transforma-la em um prompt otimizado e operacional.
 
 ---
 
-## 💻 Tecnologias Empregadas
+## Arquitetura (Multiplos Agentes)
+
+O motor C# (backend) orquestra chamadas de modelos com funcoes especificas. O frontend atua como a interface reativa dessas etapas:
+
+1. Agente de triagem de complexidade: detecta quando um pedido precisa ser quebrado em sub-tarefas.
+2. Agente de identificacao de papel e formato: define quem o LLM final precisa ser e como deve responder.
+3. Agente analitico: encontra lacunas, riscos e gotchas tecnicos.
+4. Agente gerador: monta o super prompt com base no contexto enriquecido.
+5. Agente avaliador: valida o prompt e retorna uma versao refinada com score de qualidade.
+
+---
+
+## Tecnologias Empregadas
 
 ### Frontend
 
-- **Framework:** Next.js 14+ (App Router)
-- **Engine UI:** React 18
-- **Linguagem:** TypeScript Sênior (TSDocs Integrado)
-- **Styling/Animations:** Tailwind CSS & Framer Motion
-- **Ícones:** Lucide React
+- Framework: Next.js (App Router)
+- Engine UI: React
+- Linguagem: TypeScript
+- Styling/Animations: Tailwind CSS e Framer Motion
+- Icones: Lucide React
 
 ### Backend
 
-- **Framework:** .NET 8 Web API (Minimal + Controllers Híbrido)
-- **Linguagem:** C# 12 (com XML Documentation)
-- **Integração Externa:** OpenRouter.ai (modelos livres integrados, incluindo _Meta Llama 3_ e _Arcee Trinity Large_)
-- **API Spec:** Swagger / OpenAPI
+- Framework: .NET 8 Web API (Minimal + Controllers hibrido)
+- Linguagem: C# 12
+- Integracao Externa: OpenRouter.ai
+- API Spec: Swagger / OpenAPI
 
 ---
 
-## ⚙️ Variáveis de Ambiente e Configuração
+## Variaveis de Ambiente e Configuracao
 
-### Backend (`appsettings.Development.json`)
+### Backend (`OpenRouterApiKey`)
 
-Crie no repositório `backend/` um arquivo ignorado de ambiente chamado `appsettings.Development.json`:
+O backend aceita `OpenRouterApiKey` pelas fontes padrao do ASP.NET Core. Para desenvolvimento local, use nesta ordem de preferencia:
+
+1. Variavel de ambiente
+2. `dotnet user-secrets`
+3. `backend/appsettings.Development.json` local e ignorado
+
+### Opcao 1: variavel de ambiente
+
+```powershell
+$env:OpenRouterApiKey="sk-or-v1-SUA-CHAVE"
+```
+
+### Opcao 2: `dotnet user-secrets`
+
+```bash
+cd backend
+dotnet user-secrets set "OpenRouterApiKey" "sk-or-v1-SUA-CHAVE"
+```
+
+### Opcao 3: arquivo local ignorado
+
+Use [backend/appsettings.Example.json](backend/appsettings.Example.json) como referencia e crie um `backend/appsettings.Development.json` apenas no seu ambiente local:
 
 ```json
 {
@@ -54,18 +75,20 @@ Crie no repositório `backend/` um arquivo ignorado de ambiente chamado `appsett
     }
   },
   "AllowedHosts": "*",
-  "OpenRouterApiKey": "sk-or-v1-SUA-CHAVE-ABSOLUTA-AQUI"
+  "OpenRouterApiKey": "sk-or-v1-SUA-CHAVE"
 }
 ```
 
+Nao armazene segredos reais em arquivos rastreados. `GeminiApiKey` nao e usada pelo backend atual e nao deve fazer parte do setup local.
+
 ---
 
-## 🚀 Como Rodar Localmente
+## Como Rodar Localmente
 
-### 1. Iniciar o Backend (.NET/C#)
+### 1. Iniciar o backend (.NET/C#)
 
-1. Navegue até a pasta `backend/`.
-2. Certifique-se de definir sua Key do OpenRouter como detalhado acima.
+1. Navegue ate a pasta `backend/`.
+2. Configure `OpenRouterApiKey` por uma das opcoes acima.
 3. Restaure pacotes dependentes e execute o servidor de desenvolvimento:
 
 ```bash
@@ -75,12 +98,12 @@ dotnet build
 dotnet run
 ```
 
-_O Backend expõe no padrão via `http://localhost:5117`._
+_O backend expoe por padrao `http://localhost:5117`._
 
-### 2. Iniciar o Frontend (Next.js/React)
+### 2. Iniciar o frontend (Next.js/React)
 
-1. Em um NOVO terminal separado, navegue até a pasta `frontend/`.
-2. Instale as dependências.
+1. Em um novo terminal separado, navegue ate a pasta `frontend/`.
+2. Instale as dependencias.
 3. Inicie o compilador do Next:
 
 ```bash
@@ -89,19 +112,19 @@ npm install
 npm run dev
 ```
 
-_O Frontend será orquestrado via `http://localhost:3000`._
+_O frontend fica disponivel em `http://localhost:3000`._
 
 ---
 
-## ✅ Endpoint de Self-Diagnostics
+## Endpoint de Self-Diagnostics
 
-Para comodamente medir a confiabilidade dos LLMs ou analisar fallbacks abertos no OpenRouter, dispomos de um route oculto de diagnósticos de latência.
+Para medir a disponibilidade dos modelos usados na pipeline, use o endpoint:
 
-- Dê um GET request contra `http://localhost:5117/api/modelos/testar`
-- Ele testa e pinga todas as IAs em cluster garantindo latência abaixo de <1.200ms na pipeline principal.
+- `GET http://localhost:5117/api/modelos/testar`
+- Se `OpenRouterApiKey` nao estiver configurada, o endpoint retorna `503 Service Unavailable` com uma mensagem de configuracao ausente.
 
 ---
 
 ### Equipe de Engenharia / Maintenance
 
-Este monorepo foca na clareza estrutural com Tipagem Total e Clean Architecture patterns. Pull-Requests devem acompanhar cobertura similar de TSDoc / C# XML Docs.
+Este monorepo foca em clareza estrutural, compatibilidade incremental e evolucao segura. Pull requests devem manter alinhamento entre codigo, contratos, documentacao e testes.

--- a/backend/ApiAssistente.csproj
+++ b/backend/ApiAssistente.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>assistente-super-prompt-backend</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,3 +13,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/backend/ApiAssistente.http
+++ b/backend/ApiAssistente.http
@@ -1,6 +1,16 @@
 @ApiAssistente_HostAddress = http://localhost:5117
 
-GET {{ApiAssistente_HostAddress}}/weatherforecast/
+### Requer OpenRouterApiKey configurada no backend
+GET {{ApiAssistente_HostAddress}}/api/modelos/testar
 Accept: application/json
+
+###
+
+POST {{ApiAssistente_HostAddress}}/api/prompt/gerar
+Content-Type: application/json
+
+{
+  "ideiaBruta": "Quero um prompt para gerar uma landing page moderna para um SaaS B2B."
+}
 
 ###

--- a/backend/Controllers/PromptController.cs
+++ b/backend/Controllers/PromptController.cs
@@ -10,33 +10,45 @@ namespace ApiAssistente.Controllers;
 [Route("api/[controller]")]
 public class PromptController : ControllerBase
 {
+    private const string OpenRouterApiKeyMissingMessage =
+        "OpenRouterApiKey nao configurada. Defina a chave via variavel de ambiente, dotnet user-secrets ou appsettings.Development.json local.";
     private readonly HttpClient _httpClient;
-    private readonly string _openRouterApiKey;
+    private readonly string? _openRouterApiKey;
 
     private const string MODELO_CLASSIFICADOR = "arcee-ai/trinity-large-preview:free";
     private const string MODELO_AMBIGUIDADE   = "arcee-ai/trinity-large-preview:free";
-    private const string MODELO_TRIAGEM       = "arcee-ai/trinity-large-preview:free";
-    private const string MODELO_DETECCAO      = "arcee-ai/trinity-large-preview:free";
-    private const string MODELO_ANALISE       = "arcee-ai/trinity-large-preview:free";
-    private const string MODELO_GERACAO       = "openrouter/free";
-    private const string MODELO_VALIDACAO     = "arcee-ai/trinity-large-preview:free";
-    private const string OPENROUTER_URL       = "https://openrouter.ai/api/v1/chat/completions";
+    // -- MODELOS: fallback autom�tico se modelo retornar vazio -----------------
+    private static readonly string[] MODELOS_GERACAO_FALLBACK = {
+        "google/gemini-2.0-flash-exp:free",
+        "meta-llama/llama-3.3-70b-instruct:free",
+        "mistralai/mistral-small-3.1-24b-instruct:free",
+        "qwen/qwen3-8b:free",
+    };
+    private static string MODELO_GERACAO  => MODELOS_GERACAO_FALLBACK[0];
+    private const string MODELO_TRIAGEM   = "google/gemini-2.0-flash-exp:free";
+    private const string MODELO_DETECCAO  = "google/gemini-2.0-flash-exp:free";
+    private const string MODELO_ANALISE   = "google/gemini-2.0-flash-exp:free";
+    private const string MODELO_VALIDACAO = "meta-llama/llama-3.3-70b-instruct:free";
+    private const string OPENROUTER_URL   = "https://openrouter.ai/api/v1/chat/completions";
 
     public PromptController(HttpClient httpClient, IConfiguration configuration)
     {
         _httpClient = httpClient;
-        _openRouterApiKey = configuration["OpenRouterApiKey"]?.Trim()
-            ?? throw new ArgumentNullException("OpenRouterApiKey não encontrada");
+        _openRouterApiKey = configuration["OpenRouterApiKey"]?.Trim();
     }
 
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
     // POST /api/prompt/gerar
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
     [HttpPost("gerar")]
     public async Task<IActionResult> GerarPrompt([FromBody] PromptRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.IdeiaBruta))
-            return BadRequest(new { erro = "ideiaBruta é obrigatório." });
+            return BadRequest(new { erro = "ideiaBruta � obrigat�rio." });
+
+        var configError = ValidarConfiguracaoOpenRouter();
+        if (configError is not null)
+            return configError;
 
         string modeloGeracaoUsado = MODELO_GERACAO;
 
@@ -44,20 +56,20 @@ public class PromptController : ControllerBase
         {
             string contextoImagem = "";
 
-            // ── ETAPA -2: CLASSIFICAÇÃO DE OBJETIVO ──────────────────────────
+            // -- ETAPA -2: CLASSIFICA��O DE OBJETIVO --------------------------
             var tipoFinal = await ClassificarObjetivo(request.IdeiaBruta, contextoImagem, request.TipoSugerido);
             Console.WriteLine($"[GerarPrompt] Tipo classificado: {tipoFinal}");
 
             var config = ObjetivoConfigs.Get(tipoFinal);
 
-            // ── ETAPA -1: DETECÇÃO DE AMBIGUIDADE ────────────────────────────
+            // -- ETAPA -1: DETEC��O DE AMBIGUIDADE ----------------------------
             bool jaTemRespostas = request.RespostasClarificacao?.Count > 0;
             if (!request.ForcarSimples && !jaTemRespostas)
             {
                 var perguntas = await DetectarAmbiguidade(request.IdeiaBruta, tipoFinal);
                 if (perguntas.Count > 0)
                 {
-                    Console.WriteLine($"[GerarPrompt] {perguntas.Count} perguntas de clarificação geradas");
+                    Console.WriteLine($"[GerarPrompt] {perguntas.Count} perguntas de clarifica��o geradas");
                     return Ok(new
                     {
                         tipo_resposta   = "clarificacao_necessaria",
@@ -68,12 +80,12 @@ public class PromptController : ControllerBase
                 }
             }
 
-            // ── Enriquece ideia ───────────────────────────────────────────────
+            // -- Enriquece ideia -----------------------------------------------
             string ideiaEnriquecida = MontarIdeiaEnriquecida(
                 request.IdeiaBruta, contextoImagem, request.RespostasClarificacao, request.ExecutorAlvo
             );
 
-            // ── TRIAGEM (só para código/refatoração/UI/outro) ─────────────────
+            // -- TRIAGEM (s� para c�digo/refatora��o/UI/outro) -----------------
             bool tipoExigeTriagem = tipoFinal == TipoObjetivo.Codigo
                                  || tipoFinal == TipoObjetivo.Refatoracao
                                  || tipoFinal == TipoObjetivo.DesignUI
@@ -84,7 +96,7 @@ public class PromptController : ControllerBase
                 var triagem = await TriarComplexidade(ideiaEnriquecida);
                 if (triagem.isComplexo)
                 {
-                    Console.WriteLine($"[GerarPrompt] Triagem: complexo — {triagem.subTarefas.Count} sub-tarefas");
+                    Console.WriteLine($"[GerarPrompt] Triagem: complexo � {triagem.subTarefas.Count} sub-tarefas");
                     return Ok(new
                     {
                         tipo_resposta   = "plano_de_divisao",
@@ -97,19 +109,19 @@ public class PromptController : ControllerBase
                 }
             }
 
-            // ── ETAPA 0: PAPEL + FORMATO ──────────────────────────────────────
+            // -- ETAPA 0: PAPEL + FORMATO --------------------------------------
             var deteccao = await DetectarPapelEFormato(ideiaEnriquecida, request.Papel, config);
             Console.WriteLine($"[GerarPrompt] Papel: {deteccao.papel[..Math.Min(80, deteccao.papel.Length)]}");
 
-            // ── ETAPA 1: ANÁLISE ──────────────────────────────────────────────
+            // -- ETAPA 1: AN�LISE ----------------------------------------------
             var analise = await AnalisarPorTipo(ideiaEnriquecida, tipoFinal, deteccao.papel, config);
             if (string.IsNullOrWhiteSpace(analise))
             {
-                Console.WriteLine($"[GerarPrompt] ERRO: Etapa 1 (Análise) retornou vazio. Tipo={tipoFinal}");
-                return StatusCode(500, new { erro = "Etapa 1 (Análise) falhou — resposta vazia." });
+                Console.WriteLine($"[GerarPrompt] ERRO: Etapa 1 (An�lise) retornou vazio. Tipo={tipoFinal}");
+                return StatusCode(500, new { erro = "Etapa 1 (An�lise) falhou � resposta vazia." });
             }
 
-            // ── ETAPA 2: GERAÇÃO ──────────────────────────────────────────────
+            // -- ETAPA 2: GERA��O ----------------------------------------------
             var (promptGerado, modeloReal) = await GerarPorTipo(
                 ideiaEnriquecida, tipoFinal, analise, deteccao.papel, deteccao.formato, config
             );
@@ -117,12 +129,12 @@ public class PromptController : ControllerBase
 
             if (string.IsNullOrWhiteSpace(promptGerado))
             {
-                Console.WriteLine($"[GerarPrompt] ERRO: Etapa 2 (Geração) retornou vazio. Tipo={tipoFinal} Modelo={modeloGeracaoUsado}");
-                return StatusCode(500, new { erro = "Etapa 2 (Geração) falhou — prompt vazio." });
+                Console.WriteLine($"[GerarPrompt] ERRO: Etapa 2 (Gera��o) retornou vazio. Tipo={tipoFinal} Modelo={modeloGeracaoUsado}");
+                return StatusCode(500, new { erro = "Etapa 2 (Gera��o) falhou � prompt vazio." });
             }
             Console.WriteLine($"[GerarPrompt] Prompt gerado ({promptGerado.Length} chars)");
 
-            // ── ETAPA 3: VALIDAÇÃO ────────────────────────────────────────────
+            // -- ETAPA 3: VALIDA��O --------------------------------------------
             var validacao = await ValidarPorTipo(promptGerado, tipoFinal, config);
 
             string? promptFinal = ExtrairTagXmlRobusto(validacao ?? "", "prompt_final");
@@ -164,38 +176,42 @@ public class PromptController : ControllerBase
                 },
                 pipeline = new
                 {
-                    etapa_triagem   = new { modelo = MODELO_CLASSIFICADOR, funcao = "Classificação" },
-                    etapa_0         = new { modelo = MODELO_DETECCAO,      funcao = "Detecção"      },
-                    etapa_1         = new { modelo = MODELO_ANALISE,       funcao = "Análise"       },
-                    etapa_2         = new { modelo = modeloGeracaoUsado,   funcao = "Geração"       },
-                    etapa_3         = new { modelo = MODELO_VALIDACAO,     funcao = "Validação"     },
+                    etapa_triagem   = new { modelo = MODELO_CLASSIFICADOR, funcao = "Classifica��o" },
+                    etapa_0         = new { modelo = MODELO_DETECCAO,      funcao = "Detec��o"      },
+                    etapa_1         = new { modelo = MODELO_ANALISE,       funcao = "An�lise"       },
+                    etapa_2         = new { modelo = modeloGeracaoUsado,   funcao = "Gera��o"       },
+                    etapa_3         = new { modelo = MODELO_VALIDACAO,     funcao = "Valida��o"     },
                     score_qualidade = score.Trim()
                 }
             });
         }
         catch (HttpRequestException ex)
         {
-            Console.WriteLine($"[GerarPrompt] HttpRequestException: {ex.StatusCode} — {ex.Message}");
+            Console.WriteLine($"[GerarPrompt] HttpRequestException: {ex.StatusCode} � {ex.Message}");
             return StatusCode((int)(ex.StatusCode ?? System.Net.HttpStatusCode.InternalServerError),
                 new { erro = "Erro OpenRouter", detalhes = ex.Message });
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[GerarPrompt] Exception: {ex.GetType().Name} — {ex.Message}");
+            Console.WriteLine($"[GerarPrompt] Exception: {ex.GetType().Name} � {ex.Message}");
             return StatusCode(500, new { erro = "Erro interno", detalhes = ex.Message });
         }
     }
 
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
     // POST /api/prompt/regerar
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
     [HttpPost("regerar")]
     public async Task<IActionResult> RegerarPrompt([FromBody] RegerarRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.PromptAtual))
-            return BadRequest(new { erro = "promptAtual é obrigatório." });
+            return BadRequest(new { erro = "promptAtual � obrigat�rio." });
         if (string.IsNullOrWhiteSpace(request.InstrucaoMelhora))
-            return BadRequest(new { erro = "instrucaoMelhora é obrigatório." });
+            return BadRequest(new { erro = "instrucaoMelhora � obrigat�rio." });
+
+        var configError = ValidarConfiguracaoOpenRouter();
+        if (configError is not null)
+            return configError;
 
         var tipo   = request.TipoObjetivo ?? TipoObjetivo.Outro;
         var config = ObjetivoConfigs.Get(tipo);
@@ -205,26 +221,26 @@ public class PromptController : ControllerBase
             var instrucao = tipo switch
             {
                 TipoObjetivo.Imagem or TipoObjetivo.Video =>
-                    $"Melhore este prompt de {tipo.ToString().ToLower()} aplicando: {request.InstrucaoMelhora}. Mantenha estilo técnico para {config.FerramentasAlvo}.",
+                    $"Melhore este prompt de {tipo.ToString().ToLower()} aplicando: {request.InstrucaoMelhora}. Mantenha estilo t�cnico para {config.FerramentasAlvo}.",
                 TipoObjetivo.Codigo or TipoObjetivo.Refatoracao =>
-                    $"Refine este prompt técnico aplicando: {request.InstrucaoMelhora}. Mantenha especificidade e critérios mensuráveis.",
+                    $"Refine este prompt t�cnico aplicando: {request.InstrucaoMelhora}. Mantenha especificidade e crit�rios mensur�veis.",
                 TipoObjetivo.Copywriting =>
-                    $"Melhore este prompt de copywriting: {request.InstrucaoMelhora}. Mantenha foco em conversão.",
+                    $"Melhore este prompt de copywriting: {request.InstrucaoMelhora}. Mantenha foco em convers�o.",
                 _ => $"Aplique: {request.InstrucaoMelhora}"
             };
 
             var (promptMelhorado, modeloUsado) = await ChamarOpenRouterComModelo(
                 modelo: MODELO_GERACAO, temperature: config.Temperature,
                 systemPrompt: $@"
-Você é um Arquiteto de Prompts especializado em {tipo}.
+Voc� � um Arquiteto de Prompts especializado em {tipo}.
 NUNCA descarte a estrutura existente.
-SEMPRE aplique a instrução de melhora cirurgicamente.
-SEMPRE mantenha 95%+ de força para: {config.FerramentasAlvo}.",
+SEMPRE aplique a instru��o de melhora cirurgicamente.
+SEMPRE mantenha 95%+ de for�a para: {config.FerramentasAlvo}.",
                 userPrompt: $@"
 Prompt atual:
 {request.PromptAtual}
 
-Instrução: {instrucao}
+Instru��o: {instrucao}
 Papel: {request.Papel ?? config.PapelPadrao}
 
 Retorne SOMENTE dentro das tags:
@@ -234,7 +250,7 @@ Retorne SOMENTE dentro das tags:
             );
 
             if (string.IsNullOrWhiteSpace(promptMelhorado))
-                return StatusCode(500, new { erro = "Geração do prompt melhorado falhou." });
+                return StatusCode(500, new { erro = "Gera��o do prompt melhorado falhou." });
 
             var validacao = await ValidarPorTipo(promptMelhorado, tipo, config);
             string? final = ExtrairTagXmlRobusto(validacao ?? "", "prompt_final");
@@ -253,9 +269,9 @@ Retorne SOMENTE dentro das tags:
                 prompt_otimizado = final!.Trim(),
                 pipeline = new
                 {
-                    etapa_1 = new { modelo = modeloUsado ?? MODELO_GERACAO, funcao = "Geração"   },
-                    etapa_2 = new { modelo = modeloUsado ?? MODELO_GERACAO, funcao = "Geração"   },
-                    etapa_3 = new { modelo = MODELO_VALIDACAO,              funcao = "Validação" },
+                    etapa_1 = new { modelo = modeloUsado ?? MODELO_GERACAO, funcao = "Gera��o"   },
+                    etapa_2 = new { modelo = modeloUsado ?? MODELO_GERACAO, funcao = "Gera��o"   },
+                    etapa_3 = new { modelo = MODELO_VALIDACAO,              funcao = "Valida��o" },
                     score_qualidade = sm.Success ? sm.Value : "N/A"
                 }
             });
@@ -267,24 +283,24 @@ Retorne SOMENTE dentro das tags:
         }
     }
 
-    // ════════════════════════════════════════════════════════════
-    // CLASSIFICAÇÃO DE OBJETIVO
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
+    // CLASSIFICA��O DE OBJETIVO
+    // ------------------------------------------------------------
     private async Task<TipoObjetivo> ClassificarObjetivo(
         string ideia, string contextoImagem, TipoObjetivo? tipoSugerido)
     {
         var contextoExtra = string.IsNullOrEmpty(contextoImagem)
-            ? "" : $"\nContexto visual extraído da imagem: {contextoImagem}";
+            ? "" : $"\nContexto visual extra�do da imagem: {contextoImagem}";
 
         var resultado = await ChamarOpenRouter(
             modelo: MODELO_CLASSIFICADOR, temperature: 0.1,
             systemPrompt: @"
-Você classifica o tipo de prompt que o usuário quer criar.
+Voc� classifica o tipo de prompt que o usu�rio quer criar.
 Tipos: Imagem, Video, Codigo, Refatoracao, Copywriting, DesignUI, Outro
 SEMPRE responda dentro das tags XML.",
             userPrompt: $@"
 Classifique:
-{(tipoSugerido.HasValue ? $"Usuário sugeriu: {tipoSugerido.Value}. Confirme ou corrija." : "Detecte automaticamente.")}
+{(tipoSugerido.HasValue ? $"Usu�rio sugeriu: {tipoSugerido.Value}. Confirme ou corrija." : "Detecte automaticamente.")}
 
 Pedido: '{ideia}'{contextoExtra}
 
@@ -310,47 +326,47 @@ Pedido: '{ideia}'{contextoExtra}
         };
     }
 
-    // ════════════════════════════════════════════════════════════
-    // ANÁLISE ESPECIALIZADA POR TIPO
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
+    // AN�LISE ESPECIALIZADA POR TIPO
+    // ------------------------------------------------------------
     private async Task<string?> AnalisarPorTipo(
         string ideia, TipoObjetivo tipo, string papel, ObjetivoConfig config)
     {
         var campos = tipo switch
         {
             TipoObjetivo.Imagem => @"
-  <elementos_visuais>Sujeito, materiais, texturas, cores, iluminação, composição.</elementos_visuais>
-  <estilo_artistico>Referências visuais, movimento artístico, artistas de referência.</estilo_artistico>
-  <parametros_tecnicos>Ferramenta alvo, resolução, aspect ratio, parâmetros especiais.</parametros_tecnicos>
+  <elementos_visuais>Sujeito, materiais, texturas, cores, ilumina��o, composi��o.</elementos_visuais>
+  <estilo_artistico>Refer�ncias visuais, movimento art�stico, artistas de refer�ncia.</estilo_artistico>
+  <parametros_tecnicos>Ferramenta alvo, resolu��o, aspect ratio, par�metros especiais.</parametros_tecnicos>
   <o_que_evitar>Elementos que degradam ou conflitam com o objetivo.</o_que_evitar>",
 
             TipoObjetivo.Video => @"
-  <cena_principal>Ambiente, sujeitos, ação central.</cena_principal>
-  <movimento_camera>Tipo de movimento, velocidade, transições.</movimento_camera>
-  <estilo_visual>Paleta, iluminação, atmosfera, referências.</estilo_visual>",
+  <cena_principal>Ambiente, sujeitos, a��o central.</cena_principal>
+  <movimento_camera>Tipo de movimento, velocidade, transi��es.</movimento_camera>
+  <estilo_visual>Paleta, ilumina��o, atmosfera, refer�ncias.</estilo_visual>",
 
             TipoObjetivo.Copywriting => @"
-  <persona_alvo>Quem é o leitor, suas dores e desejos.</persona_alvo>
-  <proposta_valor>O que diferencia este produto/serviço.</proposta_valor>
-  <gatilhos>Quais gatilhos usar (urgência, prova social, autoridade).</gatilhos>
-  <tom_voz>Tom, linguagem, nível de formalidade.</tom_voz>",
+  <persona_alvo>Quem � o leitor, suas dores e desejos.</persona_alvo>
+  <proposta_valor>O que diferencia este produto/servi�o.</proposta_valor>
+  <gatilhos>Quais gatilhos usar (urg�ncia, prova social, autoridade).</gatilhos>
+  <tom_voz>Tom, linguagem, n�vel de formalidade.</tom_voz>",
 
             TipoObjetivo.DesignUI => @"
-  <componentes>Quais elementos de UI são necessários.</componentes>
-  <fluxo>Jornada e interações do usuário.</fluxo>
-  <tokens>Cores, tipografia, espaçamento necessários.</tokens>",
+  <componentes>Quais elementos de UI s�o necess�rios.</componentes>
+  <fluxo>Jornada e intera��es do usu�rio.</fluxo>
+  <tokens>Cores, tipografia, espa�amento necess�rios.</tokens>",
 
             _ => @"
   <objetivo_real>O que precisa ser implementado.</objetivo_real>
-  <armadilhas>3 erros que uma implementação ruim cometeria.</armadilhas>
-  <contexto_minimo>Stack, padrões e requisitos mínimos.</contexto_minimo>
-  <restricoes>5 restrições NUNCA/SEMPRE específicas.</restricoes>"
+  <armadilhas>3 erros que uma implementa��o ruim cometeria.</armadilhas>
+  <contexto_minimo>Stack, padr�es e requisitos m�nimos.</contexto_minimo>
+  <restricoes>5 restri��es NUNCA/SEMPRE espec�ficas.</restricoes>"
         };
 
         return await ChamarOpenRouter(
             modelo: MODELO_ANALISE, temperature: 0.3,
             systemPrompt: $@"
-Você é um analista de engenharia de prompts para {tipo}.
+Voc� � um analista de engenharia de prompts para {tipo}.
 Papel: {papel} | Ferramentas: {config.FerramentasAlvo}
 NUNCA gere o prompt final. Apenas analise.
 SEMPRE responda dentro das tags XML.",
@@ -365,28 +381,28 @@ Pedido: {ideia}"
         );
     }
 
-    // ════════════════════════════════════════════════════════════
-    // GERAÇÃO ESPECIALIZADA POR TIPO
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
+    // GERA��O ESPECIALIZADA POR TIPO
+    // ------------------------------------------------------------
     private async Task<(string? texto, string? modelo)> GerarPorTipo(
         string ideia, TipoObjetivo tipo, string analise,
         string papel, string formato, ObjetivoConfig config)
     {
         var criterios = string.Join("\n    ", config.CriteriosBase.Select((c, i) => $"{i+1}. {c}"));
 
-        // Imagem e vídeo: texto direto, sem XML
+        // Imagem e v�deo: texto direto, sem XML
         if (tipo is TipoObjetivo.Imagem or TipoObjetivo.Video)
         {
             return await ChamarOpenRouterComModelo(
                 modelo: MODELO_GERACAO, temperature: config.Temperature,
                 systemPrompt: $@"
-Você é especialista em prompt engineering para {tipo} ({config.FerramentasAlvo}).
+Voc� � especialista em prompt engineering para {tipo} ({config.FerramentasAlvo}).
 NUNCA use XML no prompt gerado.
-NUNCA adicione explicações — apenas o prompt.
-SEMPRE inclua parâmetros técnicos da ferramenta no final.
+NUNCA adicione explica��es � apenas o prompt.
+SEMPRE inclua par�metros t�cnicos da ferramenta no final.
 SEMPRE extraia 95%+ do potencial da IA geradora.",
                 userPrompt: $@"
-Com base na análise:
+Com base na an�lise:
 {analise}
 
 Crie o prompt para:
@@ -394,12 +410,12 @@ Crie o prompt para:
 - Ferramenta: {config.FerramentasAlvo}
 - Papel: {papel}
 
-Critérios obrigatórios:
+Crit�rios obrigat�rios:
 {criterios}
 
 Retorne SOMENTE dentro das tags:
 <prompt_gerado>
-[prompt completo — para Midjourney inclua --ar, --v, --style no final]
+[prompt completo � para Midjourney inclua --ar, --v, --style no final]
 </prompt_gerado>"
             );
         }
@@ -408,12 +424,12 @@ Retorne SOMENTE dentro das tags:
         return await ChamarOpenRouterComModelo(
             modelo: MODELO_GERACAO, temperature: config.Temperature,
             systemPrompt: $@"
-Você é um Arquiteto de Prompts Sênior para {tipo}.
+Voc� � um Arquiteto de Prompts S�nior para {tipo}.
 NUNCA adicione texto fora das tags XML.
-NUNCA seja genérico.
-SEMPRE inclua critérios mensuráveis.",
+NUNCA seja gen�rico.
+SEMPRE inclua crit�rios mensur�veis.",
             userPrompt: $@"
-Com base na análise:
+Com base na an�lise:
 {analise}
 
 Gere o prompt para:
@@ -422,61 +438,61 @@ Gere o prompt para:
 - Ferramenta: {config.FerramentasAlvo}
 - Formato: {formato}
 
-Critérios obrigatórios:
+Crit�rios obrigat�rios:
 {criterios}
 
 Retorne SOMENTE neste XML:
 <prompt_otimizado>
   <system_instruction>{papel}. Ferramenta: {config.FerramentasAlvo}.</system_instruction>
-  <restricoes_constitucionais>6 restrições NUNCA/SEMPRE específicas para {tipo}.</restricoes_constitucionais>
-  <instrucao_principal>Tarefa única com critério de sucesso mensurável.</instrucao_principal>
+  <restricoes_constitucionais>6 restri��es NUNCA/SEMPRE espec�ficas para {tipo}.</restricoes_constitucionais>
+  <instrucao_principal>Tarefa �nica com crit�rio de sucesso mensur�vel.</instrucao_principal>
   <criterios_de_aceitacao>{criterios}</criterios_de_aceitacao>
-  <few_shot_exemplo>INPUT: exemplo realista | REASONING: raciocínio | OUTPUT: resultado correto</few_shot_exemplo>
+  <few_shot_exemplo>INPUT: exemplo realista | REASONING: racioc�nio | OUTPUT: resultado correto</few_shot_exemplo>
   <formato_resposta>{formato}</formato_resposta>
-  <loop_validacao>Verifique os {config.CriteriosBase.Length} critérios antes de entregar.</loop_validacao>
+  <loop_validacao>Verifique os {config.CriteriosBase.Length} crit�rios antes de entregar.</loop_validacao>
 </prompt_otimizado>"
         );
     }
 
-    // ════════════════════════════════════════════════════════════
-    // VALIDAÇÃO ESPECIALIZADA POR TIPO
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
+    // VALIDA��O ESPECIALIZADA POR TIPO
+    // ------------------------------------------------------------
     private async Task<string?> ValidarPorTipo(
         string promptGerado, TipoObjetivo tipo, ObjetivoConfig config)
     {
         var checklist = tipo switch
         {
             TipoObjetivo.Imagem => @"
-    Sujeito principal descrito com precisão visual: sim/não
-    Estilo artístico e referências especificados: sim/não
-    Iluminação e composição incluídos: sim/não
-    Parâmetros técnicos da ferramenta presentes: sim/não
-    Tom e atmosfera claros: sim/não",
+    Sujeito principal descrito com precis�o visual: sim/n�o
+    Estilo art�stico e refer�ncias especificados: sim/n�o
+    Ilumina��o e composi��o inclu�dos: sim/n�o
+    Par�metros t�cnicos da ferramenta presentes: sim/n�o
+    Tom e atmosfera claros: sim/n�o",
 
             TipoObjetivo.Video => @"
-    Sujeito e ação principal claros: sim/não
-    Movimento de câmera especificado: sim/não
-    Atmosfera e iluminação descritos: sim/não
-    Estilo visual de referência presente: sim/não",
+    Sujeito e a��o principal claros: sim/n�o
+    Movimento de c�mera especificado: sim/n�o
+    Atmosfera e ilumina��o descritos: sim/n�o
+    Estilo visual de refer�ncia presente: sim/n�o",
 
             TipoObjetivo.Copywriting => @"
-    Persona-alvo claramente definida: sim/não
-    Proposta de valor única presente: sim/não
-    Gatilhos psicológicos específicos: sim/não
-    CTA claro e orientado à ação: sim/não",
+    Persona-alvo claramente definida: sim/n�o
+    Proposta de valor �nica presente: sim/n�o
+    Gatilhos psicol�gicos espec�ficos: sim/n�o
+    CTA claro e orientado � a��o: sim/n�o",
 
             _ => @"
-    Papel técnico ultra-específico com stack: sim/não
-    Critérios de aceitação testáveis: sim/não
-    Exemplo few-shot técnico e realista: sim/não
-    Ausência de linguagem vaga: sim/não"
+    Papel t�cnico ultra-espec�fico com stack: sim/n�o
+    Crit�rios de aceita��o test�veis: sim/n�o
+    Exemplo few-shot t�cnico e realista: sim/n�o
+    Aus�ncia de linguagem vaga: sim/n�o"
         };
 
         return await ChamarOpenRouter(
             modelo: MODELO_VALIDACAO, temperature: 0.1,
             systemPrompt: $@"
-Você valida prompts para {tipo} ({config.FerramentasAlvo}).
-Prompts ricos e detalhados são CORRETOS — não penalize detalhamento.
+Voc� valida prompts para {tipo} ({config.FerramentasAlvo}).
+Prompts ricos e detalhados s�o CORRETOS � n�o penalize detalhamento.
 Penalize apenas genericidade e falta de especificidade.
 SEMPRE responda dentro das tags XML.",
             userPrompt: $@"
@@ -484,9 +500,9 @@ Valide este prompt para {tipo}:
 
 <validacao>
   <checklist>{checklist}</checklist>
-  <problemas_encontrados>Problemas reais. Se nenhum: Nenhum problema crítico encontrado.</problemas_encontrados>
-  <prompt_final>Corrija problemas reais. Se tudo ok: copie sem alterações.</prompt_final>
-  <score>0-100. Prompts ricos e específicos devem pontuar 85+.</score>
+  <problemas_encontrados>Problemas reais. Se nenhum: Nenhum problema cr�tico encontrado.</problemas_encontrados>
+  <prompt_final>Corrija problemas reais. Se tudo ok: copie sem altera��es.</prompt_final>
+  <score>0-100. Prompts ricos e espec�ficos devem pontuar 85+.</score>
 </validacao>
 
 Prompt:
@@ -494,35 +510,35 @@ Prompt:
         );
     }
 
-    // ════════════════════════════════════════════════════════════
-    // DETECÇÃO DE AMBIGUIDADE
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
+    // DETEC��O DE AMBIGUIDADE
+    // ------------------------------------------------------------
     private async Task<List<PerguntaClarificacao>> DetectarAmbiguidade(
         string ideiaBruta, TipoObjetivo tipo)
     {
         var exemplos = tipo switch
         {
-            TipoObjetivo.Imagem => "- 'personagem' → original ou IP existente?\n- 'estilo anime' → qual subgênero?\n- 'fundo' → transparente ou cenário elaborado?",
-            TipoObjetivo.Video  => "- 'animação' → 2D, 3D ou stop motion?\n- 'câmera' → movimento específico ou estática?",
-            TipoObjetivo.Codigo => "- 'canva' → site Canva.com ou HTML Canvas API?\n- 'mobile' → React Native, Flutter ou nativo?\n- 'banco' → qual SGBD?",
-            _ => "- Termos com múltiplos significados técnicos\n- Referências ambíguas a ferramentas"
+            TipoObjetivo.Imagem => "- 'personagem' ? original ou IP existente?\n- 'estilo anime' ? qual subg�nero?\n- 'fundo' ? transparente ou cen�rio elaborado?",
+            TipoObjetivo.Video  => "- 'anima��o' ? 2D, 3D ou stop motion?\n- 'c�mera' ? movimento espec�fico ou est�tica?",
+            TipoObjetivo.Codigo => "- 'canva' ? site Canva.com ou HTML Canvas API?\n- 'mobile' ? React Native, Flutter ou nativo?\n- 'banco' ? qual SGBD?",
+            _ => "- Termos com m�ltiplos significados t�cnicos\n- Refer�ncias amb�guas a ferramentas"
         };
 
         var resultado = await ChamarOpenRouter(
             modelo: MODELO_AMBIGUIDADE, temperature: 0.2,
             systemPrompt: $@"
-Você detecta ambiguidades críticas em pedidos para {tipo}.
+Voc� detecta ambiguidades cr�ticas em pedidos para {tipo}.
 Exemplos relevantes: {exemplos}
 NUNCA gere mais de 2 perguntas.
-SEMPRE gere opções clicáveis.
+SEMPRE gere op��es clic�veis.
 SEMPRE responda em XML.",
             userPrompt: $@"
 Detecte ambiguidades em: '{ideiaBruta}'
 
 <resultado>
-  <tem_ambiguidade>sim/não</tem_ambiguidade>
+  <tem_ambiguidade>sim/n�o</tem_ambiguidade>
   <perguntas>
-    <pergunta><id>id_unico</id><texto>Pergunta direta</texto><opcoes>A | B | C</opcoes><livre>sim/não</livre></pergunta>
+    <pergunta><id>id_unico</id><texto>Pergunta direta</texto><opcoes>A | B | C</opcoes><livre>sim/n�o</livre></pergunta>
   </perguntas>
 </resultado>"
         );
@@ -561,32 +577,32 @@ Detecte ambiguidades em: '{ideiaBruta}'
         return perguntas;
     }
 
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
     // TRIAGEM DE COMPLEXIDADE
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
     private async Task<(bool isComplexo, string aviso, List<SubTarefaItem> subTarefas, string recomendacao)>
         TriarComplexidade(string ideia)
     {
         var resultado = await ChamarOpenRouter(
             modelo: MODELO_TRIAGEM, temperature: 0.1,
             systemPrompt: @"
-Você decide se um pedido de software REALMENTE precisa ser dividido em múltiplas tarefas independentes.
+Voc� decide se um pedido de software REALMENTE precisa ser dividido em m�ltiplas tarefas independentes.
 
 REGRAS RIGOROSAS:
-- Classifique como SIMPLES se: é uma única funcionalidade, refatoração de código existente, aplicar um padrão/estilo, adicionar uma feature, corrigir bugs, criar um componente.
-- Classifique como COMPLEXO APENAS se: são claramente sistemas separados (ex: backend + frontend + banco + deploy), ou o usuário explicitamente pediu uma lista de tarefas.
-- NUNCA divida por seções de uma mesma página — isso é simples.
-- NUNCA divida refatorações — aplicar um padrão a código existente é SEMPRE simples.
-- NUNCA divida por componentes de UI — criar vários componentes é uma tarefa única.
-- Em caso de dúvida: classifique como SIMPLES.
-- Máximo 4 sub-tarefas se realmente complexo.",
+- Classifique como SIMPLES se: � uma �nica funcionalidade, refatora��o de c�digo existente, aplicar um padr�o/estilo, adicionar uma feature, corrigir bugs, criar um componente.
+- Classifique como COMPLEXO APENAS se: s�o claramente sistemas separados (ex: backend + frontend + banco + deploy), ou o usu�rio explicitamente pediu uma lista de tarefas.
+- NUNCA divida por se��es de uma mesma p�gina � isso � simples.
+- NUNCA divida refatora��es � aplicar um padr�o a c�digo existente � SEMPRE simples.
+- NUNCA divida por componentes de UI � criar v�rios componentes � uma tarefa �nica.
+- Em caso de d�vida: classifique como SIMPLES.
+- M�ximo 4 sub-tarefas se realmente complexo.",
             userPrompt: $@"
 Pedido: '{ideia}'
 
 <triagem>
   <classificacao>simples/complexo</classificacao>
-  <justificativa>Uma frase explicando POR QUE é complexo (ou deixe vazio se simples).</justificativa>
-  <sub_tarefas>TITULO | DESCRICAO | COMPLEXIDADE — uma por linha. Deixe VAZIO se simples.</sub_tarefas>
+  <justificativa>Uma frase explicando POR QUE � complexo (ou deixe vazio se simples).</justificativa>
+  <sub_tarefas>TITULO | DESCRICAO | COMPLEXIDADE � uma por linha. Deixe VAZIO se simples.</sub_tarefas>
   <recomendacao>Qual implementar primeiro. Vazio se simples.</recomendacao>
 </triagem>"
         );
@@ -600,7 +616,7 @@ Pedido: '{ideia}'
 
         var subTarefas = rawTarefas
             .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-            .Select(l => l.Trim().TrimStart('-','*','•',' '))
+            .Select(l => l.Trim().TrimStart('-', '*', ' '))
             .Where(l => !string.IsNullOrWhiteSpace(l))
             .Select(l => { var p = l.Split('|'); return new SubTarefaItem {
                 Titulo = p.Length > 0 ? p[0].Trim() : l,
@@ -611,9 +627,9 @@ Pedido: '{ideia}'
         return (true, aviso, subTarefas, recomendacao);
     }
 
-    // ════════════════════════════════════════════════════════════
-    // DETECÇÃO PAPEL + FORMATO
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
+    // DETEC��O PAPEL + FORMATO
+    // ------------------------------------------------------------
     private async Task<(string papel, string formato)> DetectarPapelEFormato(
         string ideia, string? papelUsuario, ObjetivoConfig config)
     {
@@ -623,12 +639,12 @@ Pedido: '{ideia}'
         var resultado = await ChamarOpenRouter(
             modelo: MODELO_DETECCAO, temperature: 0.2,
             systemPrompt: $@"
-Identifique o papel técnico ideal. Padrão: '{config.PapelPadrao}'.
-NUNCA seja genérico. SEMPRE inclua stack específica.
+Identifique o papel t�cnico ideal. Padr�o: '{config.PapelPadrao}'.
+NUNCA seja gen�rico. SEMPRE inclua stack espec�fica.
 SEMPRE responda em XML.",
             userPrompt: $@"
 <deteccao>
-  <papel>Papel técnico ultra-específico com stack.</papel>
+  <papel>Papel t�cnico ultra-espec�fico com stack.</papel>
   <formato>{config.FormatoPadrao}</formato>
 </deteccao>
 Tarefa: '{ideia}'"
@@ -639,21 +655,21 @@ Tarefa: '{ideia}'"
         return (papel, formato);
     }
 
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
     // HELPERS
-    // ════════════════════════════════════════════════════════════
+    // ------------------------------------------------------------
     private static string MontarIdeiaEnriquecida(
         string ideia, string contextoImagem, Dictionary<string, string>? respostas,
         string? executor = null)
     {
         var sb = new StringBuilder(ideia);
         if (!string.IsNullOrEmpty(contextoImagem))
-            sb.Append($"\n\n[ANÁLISE VISUAL DA IMAGEM DE REFERÊNCIA:\n{contextoImagem}]");
+            sb.Append($"\n\n[AN�LISE VISUAL DA IMAGEM DE REFER�NCIA:\n{contextoImagem}]");
         if (!string.IsNullOrEmpty(executor))
-            sb.Append($"\n\n[EXECUTOR DO PROMPT: {executor} — otimize a estrutura, verbosidade e formato do prompt especificamente para este assistente de código.]");
+            sb.Append($"\n\n[EXECUTOR DO PROMPT: {executor} � otimize a estrutura, verbosidade e formato do prompt especificamente para este assistente de c�digo.]");
         if (respostas?.Count > 0)
         {
-            sb.Append("\n\n[CONTEXTO ADICIONAL DO USUÁRIO:");
+            sb.Append("\n\n[CONTEXTO ADICIONAL DO USU�RIO:");
             foreach (var (id, resp) in respostas)
                 sb.Append($"\n- {id}: {resp}");
             sb.Append("]");
@@ -671,6 +687,43 @@ Tarefa: '{ideia}'"
     private async Task<(string? texto, string? modeloUsado)> ChamarOpenRouterComModelo(
         string modelo, double temperature, string systemPrompt, string userPrompt)
     {
+        // Se modelo � o principal de gera��o, usa fallback autom�tico
+        var modelos = modelo == MODELOS_GERACAO_FALLBACK[0]
+            ? MODELOS_GERACAO_FALLBACK
+            : new[] { modelo };
+
+        foreach (var m in modelos)
+        {
+            try
+            {
+                var (texto, modeloUsado) = await ChamarModeloSingle(m, temperature, systemPrompt, userPrompt);
+                if (!string.IsNullOrWhiteSpace(texto))
+                    return (texto, modeloUsado);
+                Console.WriteLine($"[Fallback] Modelo {m} retornou vazio, tentando pr�ximo...");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Fallback] Modelo {m} falhou: {ex.GetType().Name} � {ex.Message.Split('\n')[0]}. Tentando pr�ximo...");
+            }
+        }
+        Console.WriteLine("[Fallback] Todos os modelos falharam.");
+        return (null, null);
+    }
+
+    private ObjectResult? ValidarConfiguracaoOpenRouter()
+    {
+        if (!string.IsNullOrWhiteSpace(_openRouterApiKey))
+            return null;
+
+        return StatusCode(StatusCodes.Status503ServiceUnavailable, new
+        {
+            erro = OpenRouterApiKeyMissingMessage
+        });
+    }
+
+    private async Task<(string? texto, string? modeloUsado)> ChamarModeloSingle(
+        string modelo, double temperature, string systemPrompt, string userPrompt)
+    {
         var payload = new
         {
             model = modelo, temperature, max_tokens = 2048,
@@ -683,12 +736,14 @@ Tarefa: '{ideia}'"
 
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
         using var req = new HttpRequestMessage(HttpMethod.Post, OPENROUTER_URL);
-        req.Headers.Add("Authorization", $"Bearer {_openRouterApiKey}");
+        req.Headers.Add("Authorization", $"Bearer {_openRouterApiKey!}");
         req.Headers.Add("HTTP-Referer",  "https://apiassistente.local");
         req.Headers.Add("X-Title",       "ApiAssistente - Prompt Engineer");
         req.Content = content;
 
-        var res  = await _httpClient.SendAsync(req);
+        // Timeout individual por chamada � evita o TaskCanceledException do cliente global
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+        var res  = await _httpClient.SendAsync(req, cts.Token);
         res.EnsureSuccessStatusCode();
         var json = await res.Content.ReadAsStringAsync();
         var node = JsonNode.Parse(json);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,9 +1,11 @@
 using ApiAssistente.Controllers;
 
 var builder = WebApplication.CreateBuilder(args);
+const string OpenRouterApiKeyMissingMessage =
+    "OpenRouterApiKey nao configurada. Defina a chave via variavel de ambiente, dotnet user-secrets ou appsettings.Development.json local.";
 
 // ==========================================
-// 1. SERVIÇOS
+// 1. SERVI?OS
 // ==========================================
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -16,8 +18,12 @@ builder.Services.AddControllers()
         );
     });
 
-// ALTERAÇÃO: Tipado para injetar corretamente no PromptController
-builder.Services.AddHttpClient<PromptController>();
+// ALTERA??O: Tipado para injetar corretamente no PromptController
+builder.Services.AddHttpClient<PromptController>(client =>
+{
+    // Timeout global generoso ? cada chamada individual tem seu pr?prio CancellationToken de 90s
+    client.Timeout = TimeSpan.FromMinutes(8);
+});
 
 // CORS para o Next.js
 builder.Services.AddCors(options =>
@@ -31,7 +37,7 @@ builder.Services.AddCors(options =>
 });
 
 // ==========================================
-// 2. CONSTRUÇÃO DA APLICAÇÃO
+// 2. CONSTRU??O DA APLICA??O
 // ==========================================
 var app = builder.Build();
 
@@ -44,7 +50,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-// UseHttpsRedirection removido — em dev local só usamos HTTP (localhost:5117)
+// UseHttpsRedirection removido ? em dev local s? usamos HTTP (localhost:5117)
 app.UseCors("PermitirNextJs");
 app.UseAuthorization();
 app.MapControllers();
@@ -59,13 +65,13 @@ app.MapGet("/api/modelos/testar", async (IConfiguration config, IHttpClientFacto
     var apiKey = config["OpenRouterApiKey"]?.Trim();
 
     if (string.IsNullOrEmpty(apiKey))
-        return Results.BadRequest(new { erro = "OpenRouterApiKey não encontrada no appsettings.json" });
+        return Results.Json(new { erro = OpenRouterApiKeyMissingMessage }, statusCode: StatusCodes.Status503ServiceUnavailable);
 
     var modelos = new[]
     {
-        new { nome = "Análise",   id = "arcee-ai/trinity-large-preview:free",           etapa = 1 },
-        new { nome = "Geração",   id = "meta-llama/llama-3.3-70b-instruct:free",        etapa = 2 },
-        new { nome = "Validação", id = "mistralai/mistral-small-3.1-24b-instruct:free", etapa = 3 },
+        new { nome = "An?lise",   id = "arcee-ai/trinity-large-preview:free",           etapa = 1 },
+        new { nome = "Gera??o",   id = "meta-llama/llama-3.3-70b-instruct:free",        etapa = 2 },
+        new { nome = "Valida??o", id = "mistralai/mistral-small-3.1-24b-instruct:free", etapa = 3 },
     };
 
     var resultados = new List<object>();
@@ -107,7 +113,7 @@ app.MapGet("/api/modelos/testar", async (IConfiguration config, IHttpClientFacto
             {
                 var node = System.Text.Json.Nodes.JsonNode.Parse(json);
                 var texto = node?["choices"]?[0]?["message"]?["content"]?.ToString();
-                status  = "✅ online";
+                status  = "? online";
                 detalhe = string.IsNullOrWhiteSpace(texto) ? "Respondeu (sem texto)" : $"Respondeu: \"{texto.Trim()}\"";
             }
             else
@@ -115,13 +121,13 @@ app.MapGet("/api/modelos/testar", async (IConfiguration config, IHttpClientFacto
                 // Tenta extrair a mensagem de erro do OpenRouter
                 var node = System.Text.Json.Nodes.JsonNode.Parse(json);
                 var msg  = node?["error"]?["message"]?.ToString() ?? resposta.StatusCode.ToString();
-                status  = "❌ offline";
+                status  = "? offline";
                 detalhe = msg;
             }
         }
         catch (Exception ex)
         {
-            status  = "❌ erro";
+            status  = "? erro";
             detalhe = ex.Message;
         }
 
@@ -143,7 +149,7 @@ app.MapGet("/api/modelos/testar", async (IConfiguration config, IHttpClientFacto
     return Results.Ok(new
     {
         pipeline_pronto = resultados.Cast<dynamic>().All(r => ((string)r.status).Contains("online")),
-        resumo          = $"{resultados.Count(r => r.ToString()!.Contains("online"))}/3 modelos disponíveis",
+        resumo          = $"{resultados.Count(r => r.ToString()!.Contains("online"))}/3 modelos dispon?veis",
         modelos         = resultados
     });
 })

--- a/backend/appsettings.Example.json
+++ b/backend/appsettings.Example.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "OpenRouterApiKey": "sk-or-v1-SUA-CHAVE"
+}


### PR DESCRIPTION
## Descricao
Endurece a configuracao local do backend e reduz risco operacional de segredos.

Esta mudanca:
- habilita `dotnet user-secrets` no backend;
- adiciona `backend/appsettings.Example.json` como referencia segura;
- mantem `appsettings.Development.json` local fora do versionamento;
- atualiza README e `ApiAssistente.http` para refletir o setup real do repositorio;
- retorna `503 Service Unavailable` de forma deterministica quando `OpenRouterApiKey` nao estiver configurada.

Closes #1

## Como validar
1. Executar `dotnet build backend/ApiAssistente.csproj`.
2. Configurar `OpenRouterApiKey` via variavel de ambiente, `dotnet user-secrets` ou `appsettings.Development.json` local.
3. Chamar `GET /api/modelos/testar`.
4. Remover a chave do ambiente local e confirmar resposta `503` nos endpoints dependentes do OpenRouter.

## Fora de escopo
- Refactor arquitetural do backend
- Fundacao de testes automatizados
- Mudancas no frontend

## Riscos
- O repositorio ainda nao possui projeto de testes backend para cobrir esse comportamento automaticamente.
- A validacao de runtime sem chave precisa ser concluida fora desta sessao antes do merge.