### PR TITLE
docs(architecture): document current and target boundaries

### DIFF
--- a/docs/architecture/adr-001-modular-monolith-first.md
+++ b/docs/architecture/adr-001-modular-monolith-first.md
@@ -1,0 +1,67 @@
+# ADR-001: Modular Monolith First
+
+**Status:** Accepted as the current planning baseline
+
+## Context
+
+`assistente-super-prompt` is already a product-shaped monorepo with:
+
+- one Next.js frontend
+- one .NET 8 backend
+- a real multi-agent prompt pipeline
+- meaningful product flows already in use
+
+The current codebase does not yet have explicit internal boundaries.
+
+Today:
+
+- backend logic is concentrated in `PromptController`
+- frontend behavior is concentrated in `src/app/page.tsx`
+- there is no test foundation or CI guardrail yet
+
+A large rewrite or service split at this stage would increase delivery risk and reduce reviewability.
+
+## Decision
+
+We will evolve the system as a modular monolith first.
+
+That means:
+
+- keep the monorepo shape
+- keep a single frontend deployable and a single backend deployable
+- clarify boundaries internally before extracting assemblies, packages or services
+- prefer issue-sized refactors that improve contracts, testability and ownership step by step
+
+## Consequences
+
+### Positive
+
+- lower migration risk
+- easier PR review
+- better compatibility with the current product surface
+- clearer path to testing and CI without redesigning deployment
+
+### Negative
+
+- some temporary duplication or adapters may exist during the transition
+- controller-centric and page-centric code will remain for a while during staged extraction
+- architecture cleanup will take multiple iterations instead of one large rewrite
+
+### Risks
+
+- if issues become too large, the modular-monolith strategy can still turn into a hidden rewrite
+- if contracts are not formalized early, frontend/backend drift will continue
+- if tests lag behind refactors, internal boundary work will remain fragile
+
+## Alternatives Discarded
+
+- Immediate microservice split
+  - discarded because the current codebase is too boundary-immature for that move
+- Full backend rewrite into layered projects now
+  - discarded because it would mix architectural cleanup, functional risk and test foundation work in one step
+- Full frontend rewrite before API contract stabilization
+  - discarded because UI modularization without contract clarity would increase rework
+
+## Follow-up
+
+This ADR is implemented through the existing backlog, starting with architecture documentation, test foundation and contract formalization.

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -1,0 +1,162 @@
+# Current State
+
+## Scope
+This document describes the real worktree state of `assistente-super-prompt` as the baseline for incremental refactors.
+
+It is intentionally descriptive, not aspirational.
+
+## Monorepo Shape
+
+```text
+.
+â”œâ”€ backend/
+â”‚  â”œâ”€ Controllers/PromptController.cs
+â”‚  â”œâ”€ Models/PromptModels.cs
+â”‚  â”œâ”€ Program.cs
+â”‚  â”œâ”€ ApiAssistente.csproj
+â”‚  â”œâ”€ appsettings.json
+â”‚  â””â”€ appsettings.Example.json
+â”œâ”€ frontend/
+â”‚  â”œâ”€ src/app/page.tsx
+â”‚  â”œâ”€ src/app/layout.tsx
+â”‚  â”œâ”€ src/app/globals.css
+â”‚  â””â”€ package.json
+â””â”€ docs/
+   â””â”€ ai/
+```
+
+Observed gaps in the repository root:
+
+- There is no `.sln` or dedicated backend test project yet.
+- There is no `.github/workflows/` directory yet.
+- There is no frontend feature/module split yet.
+
+## Backend Today
+
+### Runtime and entrypoint
+
+- The backend is a single .NET 8 Web API project in `backend/`.
+- [`Program.cs`](/C:/Github/assistente-super-prompt/backend/Program.cs) still acts as startup and also owns an operational diagnostics endpoint: `GET /api/modelos/testar`.
+- Configuration is read directly from `IConfiguration`, with `OpenRouterApiKey` now documented as coming from environment variables, `dotnet user-secrets`, or a local ignored `appsettings.Development.json`.
+
+### Main behavioral boundary
+
+- [`PromptController.cs`](/C:/Github/assistente-super-prompt/backend/Controllers/PromptController.cs) is the dominant backend module.
+- The controller currently owns:
+  - request validation
+  - prompt pipeline orchestration
+  - ambiguity detection
+  - complexity triage
+  - role/format detection
+  - analysis, generation and validation prompts
+  - HTTP integration with OpenRouter
+  - model fallback logic
+  - timeout handling
+  - response shaping
+
+This means the current backend boundary is controller-centric, not service-centric.
+
+### Domain and contract shape
+
+- [`PromptModels.cs`](/C:/Github/assistente-super-prompt/backend/Models/PromptModels.cs) mixes:
+  - transport models (`PromptRequest`, `RegerarRequest`)
+  - domain enum (`TipoObjetivo`)
+  - helper records (`PerguntaClarificacao`, `SubTarefaItem`)
+  - objective configuration lookup (`ObjetivoConfigs`)
+- The enum `TipoObjetivo` is already a stable domain anchor and must be preserved.
+
+### Operational characteristics
+
+- OpenRouter is the only external AI integration currently wired into the backend.
+- The generation step already uses fallback models.
+- The API exposes two functional routes in the controller:
+  - `POST /api/prompt/gerar`
+  - `POST /api/prompt/regerar`
+- A diagnostics route exists outside controllers:
+  - `GET /api/modelos/testar`
+
+### Current risks
+
+- Rule orchestration, integration and HTTP concerns are tightly coupled in one controller.
+- Error handling still returns internal exception messages in some paths.
+- Configuration, diagnostics and pipeline behavior are not yet isolated into explicit modules.
+- There is no automated backend test suite yet.
+
+## Frontend Today
+
+### App structure
+
+- The frontend is a Next.js App Router application in `frontend/`.
+- The functional product surface is concentrated in a single file: [`src/app/page.tsx`](/C:/Github/assistente-super-prompt/frontend/src/app/page.tsx).
+- [`layout.tsx`](/C:/Github/assistente-super-prompt/frontend/src/app/layout.tsx) and [`globals.css`](/C:/Github/assistente-super-prompt/frontend/src/app/globals.css) are thin compared to `page.tsx`.
+
+### What `page.tsx` currently owns
+
+The page currently combines:
+
+- landing page presentation
+- goal selection UI
+- prompt request composition
+- direct `fetch` calls to the backend
+- response parsing
+- ambiguity flow UI
+- project queue / todo flow
+- regeneration flow
+- prompt history
+- `localStorage` persistence
+- output rendering and export actions
+
+The frontend is therefore page-centric and feature-coupled.
+
+### Worktree note
+
+- `page.tsx` is also an active local worktree surface.
+- Future refactors should assume the current monolithic page is the source state, not a hypothetical modular frontend that does not exist yet.
+
+### Current risks
+
+- Backend contract parsing is embedded in the page.
+- API base URL is still hardcoded in the page.
+- Product behavior and presentation are coupled.
+- The page is too large to review safely as one unit for future feature work.
+- There is no frontend test runner or component test coverage yet.
+
+## Contracts and Flows
+
+## Preserved product flows
+
+The following behaviors already exist and must be preserved through refactors:
+
+- multi-agent prompt pipeline
+- `TipoObjetivo`
+- clarificacao
+- plano de divisao
+- regeracao
+- historico
+
+## Current API response families
+
+`POST /api/prompt/gerar` currently returns one of:
+
+- `clarificacao_necessaria`
+- `plano_de_divisao`
+- `prompt_gerado`
+
+`POST /api/prompt/regerar` returns:
+
+- `prompt_melhorado`
+
+The current contract is functional but not formally versioned or centralized.
+
+## Documentation and operational guardrails today
+
+- [`README.md`](/C:/Github/assistente-super-prompt/README.md) now reflects safer local secret handling, but it is not yet the full architecture source of truth.
+- `docs/ai/` contains Codex operating prompts and review checklists.
+- There is still no repository-level CI pipeline in `.github/workflows`.
+
+## What should be preserved right now
+
+- Keep the repository as a monorepo with one frontend app and one backend app.
+- Keep the public route names stable while boundaries are being clarified internally.
+- Prefer small, reviewable refactors over large structural rewrites.
+- Do not split into separate deployables or services at this stage.

--- a/docs/architecture/target-state.md
+++ b/docs/architecture/target-state.md
@@ -1,0 +1,193 @@
+# Target State
+
+## Decision Summary
+
+The target architecture for `assistente-super-prompt` is a modular monolith, not a multi-service rewrite.
+
+The goal is to create clearer internal boundaries while preserving the current product surface and route compatibility.
+
+## Constraints
+
+These constraints are intentional:
+
+- preserve the multi-agent pipeline
+- preserve `TipoObjetivo`
+- preserve clarificacao, plano de divisao, regeracao and historico
+- preserve Next.js + React in the frontend
+- preserve .NET 8 Web API in the backend
+- avoid mega-refactors
+- prefer issue-sized slices that can be reviewed independently
+
+## Backend Target Boundaries
+
+Target internal shape:
+
+```text
+backend/
+  Api/
+    Controllers/
+    Contracts/
+    Diagnostics/
+    Filters/
+  Application/
+    PromptPipeline/
+    Regeneration/
+    Diagnostics/
+  Domain/
+    Prompting/
+    Objectives/
+    Validation/
+  Infrastructure/
+    Llm/
+    Configuration/
+    Logging/
+```
+
+### Responsibility split
+
+- `Api/`
+  - receives HTTP requests
+  - validates transport input
+  - maps application results to HTTP responses
+  - must not own orchestration logic
+- `Application/`
+  - coordinates the prompt pipeline
+  - decides flow branches such as clarificacao vs plano de divisao vs prompt final
+  - isolates use cases such as `GeneratePrompt` and `RegeneratePrompt`
+- `Domain/`
+  - owns `TipoObjetivo`
+  - owns objective configuration and prompt-related rules
+  - contains pure logic that should be unit-testable without HTTP
+- `Infrastructure/`
+  - owns OpenRouter access
+  - owns timeout, fallback and external model diagnostics mechanics
+  - owns configuration binding and runtime adapters
+
+### Backend non-goals for now
+
+- no microservices
+- no separate deployable workers
+- no public API redesign in one step
+- no immediate multi-project breakup unless tests and boundaries justify it later
+
+## Frontend Target Boundaries
+
+Target internal shape:
+
+```text
+frontend/src/
+  app/
+    page.tsx
+  features/
+    prompt-builder/
+    project-queue/
+    prompt-history/
+  lib/
+    api/
+    contracts/
+    storage/
+    config/
+```
+
+### Responsibility split
+
+- `app/page.tsx`
+  - composition root only
+  - assembles feature modules
+  - should stop owning direct API parsing and storage logic
+- `features/prompt-builder/`
+  - prompt request UI
+  - clarificacao flow
+  - result rendering
+- `features/project-queue/`
+  - plano de divisao
+  - queue and task progression
+  - per-task regeneration UX
+- `features/prompt-history/`
+  - history read/write and UI
+- `lib/api/`
+  - API client
+  - request/response mapping
+- `lib/contracts/`
+  - frontend contract types for backend payloads
+- `lib/storage/`
+  - `localStorage` adapters and persistence helpers
+- `lib/config/`
+  - environment-driven configuration such as API base URL
+
+### Frontend non-goals for now
+
+- no full redesign as part of architectural cleanup
+- no state management library unless the current split proves insufficient
+- no attempt to solve every page concern in one PR
+
+## Contract Strategy
+
+The frontend and backend should move toward explicit contracts without breaking current behavior.
+
+Incremental rule:
+
+- preserve the current JSON shapes first
+- centralize mapping second
+- only evolve contract structure after both sides have stable adapters and tests
+
+Practical implication:
+
+- backend DTOs should become explicit before new behavior is layered on top
+- frontend should consume a typed API client instead of parsing raw response objects in `page.tsx`
+
+## Testing Strategy by Boundary
+
+### Backend
+
+- unit tests for domain rules and parser helpers
+- application tests for branch decisions in the prompt pipeline
+- integration tests for `gerar`, `regerar` and diagnostics routes with fake OpenRouter responses
+
+### Frontend
+
+- unit tests for API mappers and storage helpers
+- component tests for clarificacao, history and queue flows
+- build and lint must become baseline CI gates before broader refactors
+
+## Delivery Guardrails
+
+Every future refactor should be issue-driven and respect these rules:
+
+- one issue, one branch, one PR
+- no stacked PRs by default
+- `main` remains the base branch
+- docs update when setup, architecture or contracts change
+- CI must eventually gate lint, build and tests for both apps
+
+## Backlog Reference
+
+The target state is intentionally aligned to this backlog:
+
+- [#1 Harden local config and secret handling](https://github.com/alessandrolsdev/assistente-super-prompt/issues/1)
+- [#2 Document current architecture and target boundaries](https://github.com/alessandrolsdev/assistente-super-prompt/issues/2)
+- [#3 Create backend solution and test foundation](https://github.com/alessandrolsdev/assistente-super-prompt/issues/3)
+- [#4 Formalize API contracts and error boundary](https://github.com/alessandrolsdev/assistente-super-prompt/issues/4)
+- [#5 Extract prompt orchestration and OpenRouter gateway](https://github.com/alessandrolsdev/assistente-super-prompt/issues/5)
+- [#6 Create frontend API client and shared contract mapping](https://github.com/alessandrolsdev/assistente-super-prompt/issues/6)
+- [#7 Modularize prompt builder UI and add frontend tests](https://github.com/alessandrolsdev/assistente-super-prompt/issues/7)
+- [#8 Add GitHub Actions and repo delivery guardrails](https://github.com/alessandrolsdev/assistente-super-prompt/issues/8)
+
+Recommended execution order:
+
+1. configuration and documentation baseline
+2. backend test foundation
+3. contract formalization
+4. backend orchestration extraction
+5. frontend API boundary
+6. frontend modularization and tests
+7. CI guardrails
+
+## Out of Scope Large Refactors
+
+These are explicitly out of scope until the backlog above advances:
+
+- splitting frontend and backend into multiple repos
+- introducing multiple backend services
+- rewriting the prompt pipeline from scratch
+- changing core product flows while boundaries are still unstable


### PR DESCRIPTION
## Descricao
Documenta o estado atual do monorepo e a arquitetura alvo incremental para orientar futuros refactors com boundaries claros.

Esta mudanca adiciona:
- `docs/architecture/current-state.md` com o diagnostico do worktree real;
- `docs/architecture/target-state.md` com os boundaries alvo de backend e frontend;
- `docs/architecture/adr-001-modular-monolith-first.md` com a decisao de evoluir como monolito modular.

Closes #2

## Como validar
1. Ler `docs/architecture/current-state.md` e confirmar aderencia ao repositorio atual.
2. Ler `docs/architecture/target-state.md` e confirmar que os boundaries propostos sao incrementais e consistentes com a stack atual.
3. Ler `docs/architecture/adr-001-modular-monolith-first.md` e confirmar alinhamento com o backlog existente.

## Fora de escopo
- Implementacao de boundaries no backend ou frontend
- Fundacao de testes
- GitHub Actions
- Refactors funcionais

## Riscos
- O worktree ainda tem mudancas locais fora deste PR em `frontend/src/app/page.tsx`.
- `docs/ai/` continua fora deste escopo e nao entra neste commit.